### PR TITLE
Add 'html' option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setuptools.setup(
         "excel": excel_requires,
         "es5": ["elasticsearch>=5.5.2,<6.0.0"],
         "es6": es6_requires,
+        "html": html_requires,
         "from": from_requires,
         "logging": logging_requires,
         "release": ["releasecmd>=0.0.12,<0.1.0"],


### PR DESCRIPTION
Fixes #9.

The `html` option was missed from `extras_require` in https://github.com/thombashi/pytablewriter/commit/0f47cca7f609da4d38ee14dc9c3b70c68eee2964.