### PR TITLE
Remove some old Python <= 3.3 code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setuptools.setup(
         "Tracker": "{:s}/issues".format(REPOSITORY_URL),
     },
 
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=setuptools_require + install_requires,
     setup_requires=setuptools_require + pytest_runner_require,
     tests_require=tests_requires,


### PR DESCRIPTION
EOL Python 3.3 was dropped in https://github.com/thombashi/pytablewriter/commit/e409b62a313920638559bd1d0ec2cb10f665d8fe.

This PR removes some redundant requirements for Python <= 3.3, and makes sure not to install for users with Python 3.3.