### PR TITLE
Make "sort_keys" not True by default

### DIFF
--- a/pytablewriter/writer/text/_json.py
+++ b/pytablewriter/writer/text/_json.py
@@ -90,7 +90,7 @@ class JsonTableWriter(IndentationTextTableWriter):
 
             json_text_list = []
             for json_data in self._table_value_matrix:
-                json_text = json.dumps(json_data, sort_keys=True, indent=4 * self._indent_level)
+                json_text = json.dumps(json_data, indent=4 * self._indent_level)
                 json_text = strip_quote(
                     json_text, self._dp_extractor.type_value_map.get(Typecode.NONE)
                 )


### PR DESCRIPTION
There is no reason to sort the keys if the user has not asked.
Perhaps we can make it into an argument in a future release.