### PR TITLE
Fix typo

### DIFF
--- a/pytablewriter/style/_style.py
+++ b/pytablewriter/style/_style.py
@@ -218,5 +218,5 @@ class Style:
 
         if not isinstance(value, expected_type):
             raise TypeError(
-                "{} must be a {} instancce: actual={}".format(attr_name, expected, type(value))
+                "{} must be instance of {}: actual={}".format(attr_name, expected, type(value))
             )


### PR DESCRIPTION
Ran into this exception at https://github.com/hugovk/pypistats/issues/101, here's some wording fixes:

"instancce" -> "instance" 

And reword to avoid for "a Align instance"