### PR TITLE
Markdown alignment cells respect margin

### DIFF
--- a/pytablewriter/writer/text/_markdown.py
+++ b/pytablewriter/writer/text/_markdown.py
@@ -65,7 +65,7 @@ class MarkdownTableWriter(IndentationTextTableWriter):
     def _get_header_row_separator_items(self) -> List[str]:
         header_separator_list = []
         for col_dp in self._column_dp_list:
-            padding_len = self._get_padding_len(col_dp) + self.margin * 2
+            padding_len = self._get_padding_len(col_dp)
             align = self._get_align(col_dp.column_index, col_dp.align)
 
             if align == Align.RIGHT:
@@ -74,6 +74,10 @@ class MarkdownTableWriter(IndentationTextTableWriter):
                 separator_item = ":" + "-" * (padding_len - 2) + ":"
             else:
                 separator_item = "-" * padding_len
+
+            margin =  " " * self.margin
+
+            separator_item = margin + separator_item + margin
 
             header_separator_list.append(separator_item)
 

--- a/test/writer/text/test_markdown_writer.py
+++ b/test/writer/text/test_markdown_writer.py
@@ -789,7 +789,7 @@ class Test_MarkdownTableWriter_write_table:
             """\
             # style filter
             | left | center | right | overwrite l | overwrite c | overwrite r |
-            |-----:|--------|-------|:-----------:|------------:|:-----------:|
+            | ---: | ------ | ----- | :---------: | ----------: | :---------: |
             | 1.0  |   c    |     r | 1.0         |      c      |           r |
             |  2.2 | left   | left  |     2.2     |       right |   center    |
             """
@@ -1009,7 +1009,7 @@ class Test_MarkdownTableWriter_write_table:
         expected = dedent(
             """\
             |  a  |   b   |  c  | dd  |  e   |
-            |----:|------:|-----|----:|------|
+            | --: | ----: | --- | --: | ---- |
             |   1 | 123.1 | a   | 1.0 |    1 |
             |   2 |   2.2 | bb  | 2.2 |  2.2 |
             |   3 |   3.3 | ccc | 3.0 | cccc |
@@ -1030,7 +1030,7 @@ class Test_MarkdownTableWriter_write_table:
         expected = dedent(
             """\
             |   a   |    b    |   c   |  dd   |   e    |
-            |------:|--------:|-------|------:|--------|
+            |  --:  |  ----:  |  ---  |  --:  |  ----  |
             |    1  |  123.1  |  a    |  1.0  |     1  |
             |    2  |    2.2  |  bb   |  2.2  |   2.2  |
             |    3  |    3.3  |  ccc  |  3.0  |  cccc  |


### PR DESCRIPTION
This PR updates the Markdown writer so that alignment cells use margins the same way that header and content cells do.

Closes #35.