### PR TITLE
Remove trailing whitespace when table does not have a name

### DIFF
--- a/pytablewriter/writer/text/_rst.py
+++ b/pytablewriter/writer/text/_rst.py
@@ -60,7 +60,7 @@ class RstTableWriter(IndentationTextTableWriter):
 
     def _get_table_directive(self) -> str:
         if typepy.is_null_string(self.table_name):
-            return ".. table:: \n"
+            return ".. table::\n"
 
         return f".. table:: {MultiByteStrDecoder(self.table_name).unicode_str}\n"
 
@@ -119,12 +119,12 @@ class RstCsvTableWriter(RstTableWriter):
         IndentationTextTableWriter.write_table(self, **kwargs)
 
     def _get_opening_row_items(self) -> List[str]:
-        directive = ".. csv-table:: "
+        directive = ".. csv-table::"
 
         if typepy.is_null_string(self.table_name):
             return [directive]
 
-        return [directive + MultiByteStrDecoder(self.table_name).unicode_str]
+        return [f"{directive} {MultiByteStrDecoder(self.table_name).unicode_str}"]
 
     def _write_opening_row(self) -> None:
         self.dec_indent_level()

--- a/test/writer/text/rst/test_rst_csv_writer.py
+++ b/test/writer/text/rst/test_rst_csv_writer.py
@@ -49,7 +49,7 @@ normal_test_data_list = [
         value=None,
         expected=dedent(
             """\
-            .. csv-table:: 
+            .. csv-table::
                 :header: "a", "b", "c", "dd", "e"
                 :widths: 3, 3, 3, 4, 3
 
@@ -63,7 +63,7 @@ normal_test_data_list = [
         value=value_matrix,
         expected=dedent(
             """\
-            .. csv-table:: 
+            .. csv-table::
                 :widths: 1, 5, 5, 3, 6
 
                 1, 123.1, "a", 1.0, 1
@@ -77,7 +77,7 @@ normal_test_data_list = [
         indent=1,
         header=headers,
         value=value_matrix,
-        expected="""    .. csv-table:: 
+        expected="""    .. csv-table::
         :header: "a", "b", "c", "dd", "e"
         :widths: 3, 5, 5, 4, 6
 

--- a/test/writer/text/rst/test_rst_grid_writer.py
+++ b/test/writer/text/rst/test_rst_grid_writer.py
@@ -53,7 +53,7 @@ normal_test_data_list = [
         value=None,
         expected=dedent(
             """\
-            .. table:: 
+            .. table::
 
                 +-+-+-+--+-+
                 |a|b|c|dd|e|
@@ -69,7 +69,7 @@ normal_test_data_list = [
         value=value_matrix,
         expected=dedent(
             """\
-            .. table:: 
+            .. table::
 
                 +-+-----+---+---+----+
                 |1|123.1|a  |1.0|   1|

--- a/test/writer/text/rst/test_rst_simple_writer.py
+++ b/test/writer/text/rst/test_rst_simple_writer.py
@@ -50,7 +50,7 @@ normal_test_data_list = [
         value=None,
         expected=dedent(
             """\
-            .. table:: 
+            .. table::
 
                 =  =  =  ==  =
                 a  b  c  dd  e
@@ -66,7 +66,7 @@ normal_test_data_list = [
         value=value_matrix,
         expected=dedent(
             """\
-            .. table:: 
+            .. table::
 
                 =  =====  ===  ===  ====
                 1  123.1  a    1.0     1
@@ -81,7 +81,7 @@ normal_test_data_list = [
         indent=1,
         header=headers,
         value=value_matrix,
-        expected="""    .. table:: 
+        expected="""    .. table::
 
         =  =====  ===  ===  ====
         a    b     c   dd    e  


### PR DESCRIPTION
I noticed that when I was writing out RST tables without a table name, the resulting file had trailing whitespace.

While I could of course post-process the file as a workaround, I thought that I'd submit a patch upstream to fix the issue in the first place.

### Example code that reproduces the problem:

```python
import pytablewriter

with open('test.rst', 'w') as fout:
  writer = pytablewriter.RstGridTableWriter()
  writer.header_list = ["Column 1", "Column 2"]
  writer.type_hint_list = [pytablewriter.String, pytablewriter.String]

  writer.value_matrix = [
    ['foo1', 'bar1'],
    ['foo2', 'bar2'],
  ]

  writer.stream = fout
  writer.write_table()
```

The `.. table::` line will have a trailing space character. This PR removes that trailing space character.