### PR TITLE
Remove runtime dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setuptools.setup(
         "Tracker": f"{REPOSITORY_URL:s}/issues",
     },
     python_requires=">=3.9",
-    install_requires=setuptools_require + install_requires,
+    install_requires=install_requires,
     setup_requires=setuptools_require,
     extras_require={
         "all": all_requires,


### PR DESCRIPTION
Hello 👋 

I first thought of opening an issue but since it's a small change I decided to open a PR and start the conversation here.

`setuptools` doesn't really seem to be used at runtime, so it should be fine to remove it and that's one fewer dependency installed into users' virtualenvs.

Let me know what you think 🙂 