### PR TITLE
Support Markdown tables without padding

### DIFF
--- a/pytablewriter/writer/text/_markdown.py
+++ b/pytablewriter/writer/text/_markdown.py
@@ -97,7 +97,9 @@ class MarkdownTableWriter(IndentationTextTableWriter):
         margin = " " * self.margin
 
         for col_dp in self._column_dp_list:
-            padding_len = self._get_padding_len(col_dp)
+            # columns in a header separator row must have at least one dash
+            # using a minimum of three accounts for right and center alignment
+            padding_len = max(3, self._get_padding_len(col_dp))
             align = self._get_align(col_dp.column_index, col_dp.align)
 
             if align == Align.RIGHT:

--- a/test/writer/text/test_markdown_writer.py
+++ b/test/writer/text/test_markdown_writer.py
@@ -1405,6 +1405,86 @@ class Test_MarkdownTableWriter_write_table:
 
         assert out == expected
 
+    def test_normal_without_padding(self, capsys):
+        writer = table_writer_class(
+            headers=["row", "a longer column name", "a"],
+            value_matrix=[
+                [1, "some long value in this cell", "b"],
+                [2, "medium", "c"]
+            ],
+            is_padding=False,
+        )
+        writer.write_table()
+
+        expected = dedent(
+            """\
+            |row|a longer column name|a|
+            |--:|---|---|
+            |1|some long value in this cell|b|
+            |2|medium|c|
+            """
+        )
+
+        out, err = capsys.readouterr()
+        print_test_result(expected=expected, actual=out, error=err)
+
+        assert out == expected
+
+    def test_normal_margin_without_padding(self, capsys):
+        writer = table_writer_class(
+            headers=["row", "a longer column name", "a"],
+            value_matrix=[
+                [1, "some long value in this cell", "b"],
+                [2, "medium", "c"]
+            ],
+            is_padding=False,
+            margin=2,
+        )
+        writer.write_table()
+
+        expected = dedent(
+            """\
+            |  row  |  a longer column name  |  a  |
+            |  --:  |  ---  |  ---  |
+            |  1  |  some long value in this cell  |  b  |
+            |  2  |  medium  |  c  |
+            """
+        )
+
+        out, err = capsys.readouterr()
+        print_test_result(expected=expected, actual=out, error=err)
+
+        assert out == expected
+
+    def test_normal_align_without_padding(self, capsys):
+        writer = table_writer_class(
+            headers=["a", "b", "c", "d"],
+            value_matrix=[
+                [1, "2", "three", 4],
+            ],
+            is_padding=False,
+            column_styles=[
+                Style(align=Align.LEFT),
+                Style(align=Align.RIGHT),
+                Style(align=Align.CENTER),
+                Style(align=Align.AUTO),
+            ]
+        )
+        writer.write_table()
+
+        expected = dedent(
+            """\
+            |a|b|c|d|
+            |---|--:|:-:|--:|
+            |1|2|three|4|
+            """
+        )
+
+        out, err = capsys.readouterr()
+        print_test_result(expected=expected, actual=out, error=err)
+
+        assert out == expected
+
 
 class Test_MarkdownTableWriter_write_table_iter:
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR makes it possible to render markdown tables without padding using the existing `is_padding` argument.

Rendering a table with a header or value that is extremely long results in an excessively padded table. While the resulting table is (potentially) easier for humans to read, it is functionally equivalent[^1] once the markdown is rendered.

When using the table somewhere with limited space (e.g., a GitHub issue/PR body) not having the padding allows for a "larger" table (no characters wasted on padding) or more content in addition to the table.

> [!NOTE]
> The `is_padding` argument removes the padding today but the header separator row requires at least one `-` for proper rendering. With this change you can write a _valid_ markdown table, without padding.

## :eyes: Usage and Examples

Pass `is_padding=False` to `MarkdownTableWriter` to render a table without padding. **The existing default behavior (table with padding) remains unchanged.**

```py3
>>> from pytablewriter import MarkdownTableWriter
>>> MarkdownTableWriter(headers=["foo", "bar"], value_matrix=[["one really long string", 123456],["foo", 1381290238121]], is_padding=False).write_table()
|foo|bar|
|---|--:|
|one really long string|123456|
|foo|1381290238121|
>>> MarkdownTableWriter(headers=["foo", "bar"], value_matrix=[["one really long string", 123456],["foo", 1381290238121]]).write_table()
|         foo          |     bar     |
|----------------------|------------:|
|one really long string|       123456|
|foo                   |1381290238121|
>>> 
```

These two tables are equivalent when rendered:

### With padding (current behavior)

```md
|row|    a longer column name    | a |
|--:|----------------------------|---|
|  1|some long value in this cell|b  |
|  2|medium                      |c  |
```

<details>
<summary>Rendered</summary>

|row|    a longer column name    | a |
|--:|----------------------------|---|
|  1|some long value in this cell|b  |
|  2|medium                      |c  |

</details>

### Without padding (new behavior, with `is_padding=False`)

```md
|row|a longer column name|a|
|--:|---|---|
|1|some long value in this cell|b|
|2|medium|c|
```

<details>
<summary>Rendered</summary>

|row|a longer column name|a|
|--:|---|---|
|1|some long value in this cell|b|
|2|medium|c|

</details>

## :thought_balloon: Other thoughts

1. Should `MarkdownTableWriter` default to no padding now, in a future (breaking) release, or never?
2. Would it make sense to have a different argument for this behavior? [Reference documentation](https://pytablewriter.readthedocs.io/en/latest/pages/reference/writers/text/markup/md.html) doesn't appear to show parent class properties (`is_padding`) but it [seems like it should?](https://github.com/thombashi/pytablewriter/blob/5da77a0b64e15451aceed41350712425d95ead62/docs/pages/reference/writers/text/markup/md.rst?plain=1#L6) :thinking:
3. Would an example in the docs be valuable (e.g., `md_example_without_padding.txt`)?

[^1]: At least for [GitHub Flavored Markdown](https://github.github.com/gfm/), and I wasn't able to find anything stating that CommonMark or kramdown require padding for tables.