### PR TITLE
Fix example style filter docs

### DIFF
--- a/docs/pages/examples/table_format/text/markdown/markdown.rst
+++ b/docs/pages/examples/table_format/text/markdown/markdown.rst
@@ -16,4 +16,4 @@ GitHub flavored Markdown (GFM)
 
 Apply styles to GFM table with programmatically (style filter)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. include:: md_example_with_style_style.txt
+.. include:: md_example_with_style_filter.txt


### PR DESCRIPTION
This PR fixes the docs for the Markdown style filter which was including the wrong file.

- cc https://pytablewriter.readthedocs.io/en/latest/pages/examples/table_format/text/markdown/markdown.html#apply-styles-to-gfm-table-with-programmatically-style-filter

## Before

<img width="1013" height="662" alt="Screenshot 2025-07-14 at 10 30 43 AM" src="https://github.com/user-attachments/assets/f7bea92a-3f15-47fb-bf9d-3d663aba1722" />

## After

<img width="1016" height="820" alt="Screenshot 2025-07-14 at 10 31 34 AM" src="https://github.com/user-attachments/assets/cb67cca0-8a9e-4553-951c-a613f59dbd6b" />