### PR TITLE
fix(PythonCodeTableWriter): emit float("-inf") for negative infinity

### DIFF
--- a/pytablewriter/writer/text/sourcecode/_python.py
+++ b/pytablewriter/writer/text/sourcecode/_python.py
@@ -1,10 +1,15 @@
+import math
 from typing import Any
 
 import typepy
+from dataproperty import ColumnDataProperty, DataProperty
 
 from ...._function import dateutil_datetime_formatter, quote_datetime_formatter
 from ....sanitizer import sanitize_python_var_name
 from ._sourcecode import SourceCodeTableWriter
+
+_NEG_INF_LITERAL = 'float("-inf")'
+_POS_INF_LITERAL = 'float("inf")'
 
 
 class PythonCodeTableWriter(SourceCodeTableWriter):
@@ -30,6 +35,7 @@ class PythonCodeTableWriter(SourceCodeTableWriter):
 
             - |None|: written as ``None``
             - |inf|: written as ``float("inf")``
+            - ``-inf``: written as ``float("-inf")``
             - |nan|: written as ``float("nan")``
             - |datetime| instances determined by |is_datetime_instance_formatting| attribute:
                 - |True|: written as `dateutil.parser <https://dateutil.readthedocs.io/en/stable/parser.html>`__
@@ -54,9 +60,22 @@ class PythonCodeTableWriter(SourceCodeTableWriter):
 
         self._dp_extractor.type_value_map = {
             typepy.Typecode.NONE: None,
-            typepy.Typecode.INFINITY: 'float("inf")',
+            typepy.Typecode.INFINITY: _POS_INF_LITERAL,
             typepy.Typecode.NAN: 'float("nan")',
         }
+
+    def _to_row_item(self, row_idx: int, col_dp: ColumnDataProperty, value_dp: DataProperty) -> str:
+        # type_value_map maps every Typecode.INFINITY to float("inf"), but
+        # dataproperty loses the sign of -inf before the map is applied.
+        # Recover the sign by checking the original value in value_matrix.
+        if value_dp.data == _POS_INF_LITERAL:
+            try:
+                orig = self.value_matrix[row_idx][col_dp.column_index]
+                if isinstance(orig, float) and math.isinf(orig) and orig < 0:
+                    value_dp = DataProperty(_NEG_INF_LITERAL)
+            except (IndexError, TypeError):
+                pass
+        return super()._to_row_item(row_idx, col_dp, value_dp)
 
     def get_variable_name(self, value: str) -> str:
         return sanitize_python_var_name(self.table_name, "_").lower()

--- a/test/writer/text/sourcecode/test_python_code_writer.py
+++ b/test/writer/text/sourcecode/test_python_code_writer.py
@@ -2,6 +2,8 @@
 .. codeauthor:: Tsuyoshi Hombashi <tsuyoshi.hombashi@gmail.com>
 """
 
+import math
+
 import pytest
 
 import pytablewriter as ptw
@@ -114,6 +116,23 @@ normal_test_data_list = [
     [0.03785679191278808, 826.21158713263],
     [None, 826.21158713263],
     [0.1, 1.0499675627886724],
+]
+""",
+    ),
+    Data(
+        table="neg-inf",
+        indent=0,
+        header=["val"],
+        value=[
+            [-math.inf],
+            [math.inf],
+            [float("nan")],
+        ],
+        expected="""neg_inf = [
+    ["val"],
+    [float("-inf")],
+    [float("inf")],
+    [float("nan")],
 ]
 """,
     ),


### PR DESCRIPTION
## Problem

`PythonCodeTableWriter` renders `float("-inf")` (negative infinity) as
`float("inf")` — valid Python syntax but the wrong value, silently
producing positive infinity when the generated code is executed.

```python
import math, pytablewriter

writer = pytablewriter.PythonCodeTableWriter()
writer.table_name = "data"
writer.headers = ["val"]
writer.value_matrix = [[-math.inf], [math.inf]]
print(writer.dumps())
```

Before this fix:
```python
data = [
    ["val"],
    [float("inf")],   # ← should be float("-inf")
    [float("inf")],
]
```

## Root cause

`dataproperty` normalises every infinity value to `Decimal('Infinity')`
before `type_value_map` is applied, losing the sign.  Both `math.inf`
and `-math.inf` therefore hit the same map entry
`{Typecode.INFINITY: 'float("inf")'}`.

## Fix

Override `_to_row_item` in `PythonCodeTableWriter` to check the
original value in `value_matrix` when the mapped literal is
`float("inf")`.  If the original was a negative-infinity float,
substitute `float("-inf")` instead.

## After this fix

```python
data = [
    ["val"],
    [float("-inf")],  # ✓ correct
    [float("inf")],   # ✓ correct
]
```

## Tests

Added a parametrised test case covering `-inf`, `+inf`, and `nan` to
`test/writer/text/sourcecode/test_python_code_writer.py`.

---

This pull request was prepared with the assistance of AI, under my direction and review.